### PR TITLE
Secure unregister actions with teacher-only authentication

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,6 +6,7 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 - View all available extracurricular activities
 - Sign up for activities
+- Teacher-only unregister with authentication and confirmation
 
 ## Getting Started
 
@@ -31,6 +32,16 @@ A super simple FastAPI application that allows students to view and sign up for 
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
 | POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| GET    | `/auth/teacher`                                                   | Validate teacher credentials (HTTP Basic)                           |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student (teacher auth required)                        |
+
+## Teacher Authentication
+
+- Teacher credentials are loaded from `teachers.json`.
+- Default local credentials are:
+   - Username: `teacher`
+   - Password: `changeme123`
+- You should change these values before real usage.
 
 ## Data Model
 

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,6 +8,13 @@
   </head>
   <body>
     <header>
+      <div id="teacher-auth" class="teacher-auth">
+        <input type="text" id="teacher-username" placeholder="Teacher username" autocomplete="username" />
+        <input type="password" id="teacher-password" placeholder="Password" autocomplete="current-password" />
+        <button id="teacher-login-btn" type="button">Teacher Login</button>
+        <button id="teacher-logout-btn" type="button" class="hidden">Logout</button>
+      </div>
+      <p id="teacher-status" class="teacher-status">Teacher mode is off. Unregister is restricted.</p>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
     </header>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -28,6 +28,27 @@ header h1 {
   margin-bottom: 10px;
 }
 
+.teacher-auth {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 8px;
+}
+
+.teacher-auth input {
+  padding: 8px 10px;
+  border: 1px solid #c5cae9;
+  border-radius: 4px;
+  min-width: 180px;
+}
+
+.teacher-status {
+  margin-bottom: 12px;
+  font-size: 14px;
+  color: #e8eaf6;
+}
+
 main {
   display: flex;
   flex-wrap: wrap;

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,8 @@
+{
+  "teachers": [
+    {
+      "username": "teacher",
+      "password": "changeme123"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implements issue #11 by securing unregister/delete controls to teacher mode and adding explicit confirmation before destructive actions.

## What changed
- Added backend teacher authentication using HTTP Basic and credentials from `src/teachers.json`.
- Protected `DELETE /activities/{activity_name}/unregister` with teacher auth.
- Added `GET /auth/teacher` for teacher credential validation.
- Added audit-friendly server logs for unauthorized attempts and successful unregister actions.
- Added frontend teacher login/logout UI in the header.
- Hid unregister buttons unless teacher mode is authenticated.
- Added confirmation dialog before unregistering a participant.
- Updated `src/README.md` with auth and endpoint documentation.

## Validation
- Unauthenticated unregister returns `401 Unauthorized`.
- Authenticated teacher can access `/auth/teacher` and successfully unregister participants.

## Notes
- Default local teacher credentials are in `src/teachers.json` and should be changed for real usage.
- This PR focuses on #11. It overlaps with issue #5 but does not fully implement all #5 requirements.